### PR TITLE
Support RHEL 7 `check-update` reduced width output

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This repo is intended to provide various tools used to monitor memory usage.
 
 | Tool Name | Overall Status | Description                                                                                                                        |
 | --------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `yum2md`  | Beta           | CLI tool to convert `yum check-update` / `dnf check-update` output (RHEL 8+) from stdin into a Markdown-formatted table on stdout. |
+| `yum2md`  | Beta           | CLI tool to convert `yum check-update` / `dnf check-update` output (RHEL 7+) from stdin into a Markdown-formatted table on stdout. |
 
 ## Changelog
 

--- a/cmd/yum2md/main.go
+++ b/cmd/yum2md/main.go
@@ -11,36 +11,99 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/atc0005/yum2md/internal/checkupdate"
 )
 
+func processLine(line string, incompleteFields *[]string) ([]string, bool) {
+	if line == "" {
+		return nil, true
+	}
+
+	// Skip over header for obsolete packages section and all lines
+	// following it.
+	if strings.TrimSpace(line) == checkupdate.ObsoletePackagesHeader {
+		return nil, true
+	}
+
+	fields := strings.Fields(line)
+
+	// RHEL 7+ yum/dnf safety rule:
+	// Only accept lines that can form exactly:
+	//   package | release | repo
+	//
+	// We attempt to exclude known problematic patterns and hotfix any
+	// check-update output that may be incorrectly broken over multiple
+	// lines. This may occur from `yum` incorrectly detecting that it is
+	// writing output to a reduced width terminal.
+	switch {
+	case len(fields) == 0:
+		// Skip blank lines.
+		return nil, true
+
+	case len(fields) < 3 && len(*incompleteFields) == 0:
+		// We have less than three fields after splitting the input and
+		// don't currently have a saved copy of the available fields from
+		// a previous line which didn't match the required count.
+		//
+		// Save current fields and attempt to reconstruct on the next pass
+		// with the following line. We rely on later validation to reject
+		// any invalid input lines that happens to also contain 3 fields.
+		*incompleteFields = slices.Clone(fields)
+
+		return nil, true
+
+	case len(fields)+len(*incompleteFields) == 3:
+		// Attempt to detect and hotfix unexpected line wrapping.
+		//
+		// Example 1:
+		//
+		//    ca-certificates.noarch           2025.2.80_v9.0.304-71.el7_9
+		//                                                              rhel-7-server-els-rpms
+		//
+		// Example 2:
+		//
+		//    device-mapper-persistent-data.x86_64
+		//                                     0.8.5-3.el7_9.2          rhel-7-server-els-rpms
+		fields = append(*incompleteFields, fields...)
+
+		// CRITICAL step; we need to wipe the buffer after retrieving its
+		// contents to prevent unexpected reuse.
+		*incompleteFields = nil
+
+		return fields, false
+
+	case len(fields) < 3 && len(*incompleteFields) != 0:
+		// fmt.Println("DEBUG: Failed to match previous incomplete line and this one")
+		// fmt.Printf("DEBUG: Previous incomplete line: %q, this one: %q\n", incompleteFields, fields)
+		// fmt.Printf("DEBUG: len(fields)==%d, len(incompleteFields)==%d\n", len(fields), len(incompleteFields))
+
+		// We attempted to capture the previous incomplete line and match
+		// that up with the current line and that didn't work out. Let's
+		// clear the previous saved line and save the current one instead.
+		*incompleteFields = slices.Clone(fields)
+
+		// Let's try the next line.
+		return nil, true
+
+	}
+
+	return fields, false
+}
+
 func main() {
 	scanner := bufio.NewScanner(os.Stdin)
 
+	var incompleteFields []string
 	var rows []checkupdate.Row
 
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
-		}
 
-		// Skip over header for obsolete packages section and all lines
-		// following it.
-		if strings.TrimSpace(line) == checkupdate.ObsoletePackagesHeader {
-			break
-		}
-
-		fields := strings.Fields(line)
-
-		// RHEL 8+ yum/dnf safety rule:
-		// Only accept lines that can form exactly:
-		//   package | release | repo
-		// if len(fields) < 3 {
-		// if len(fields) < 3 || len(fields) > 3 {
-		if len(fields) != 3 {
+		fields, skipLine := processLine(line, &incompleteFields)
+		if skipLine {
 			continue
 		}
 
@@ -59,7 +122,7 @@ func main() {
 		// Skip over any lines which do not contain a separator character in expected fields.
 		if !checkupdate.CollectionContainsPackageNameSeparator(fields) {
 			// fmt.Println("Skipping line due to collectionContainsPackageNameSeparator check")
-			// fmt.Println("SKIPPED:", fields)
+			// fmt.Printf("SKIPPED:%q\n", fields)
 			continue
 		}
 


### PR DESCRIPTION
Add support for handling `yum check-update` for RHEL 7 incorrectly detecting reduced width output and unexpectedly splitting three column output across multiple lines.